### PR TITLE
Ensure service worker runs as ES module

### DIFF
--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,0 +1,8 @@
+import fs from 'fs';
+
+const manifestPath = new URL('../src/manifest.json', import.meta.url);
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+test('service worker is an ES module', () => {
+  expect(manifest.background.type).toBe('module');
+});


### PR DESCRIPTION
## Summary
- add a small Jest test to ensure manifest specifies module type for the service worker

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ee892c158832aa9f1da384fe67284